### PR TITLE
mkdir $CHARM_DIR/lib if it does not exist

### DIFF
--- a/neutron-api-cplane/hooks/cplane_package_manager.py
+++ b/neutron-api-cplane/hooks/cplane_package_manager.py
@@ -6,6 +6,10 @@ import json
 import hashlib
 import urlparse
 
+from charmhelpers.core.host import (
+    mkdir,
+)
+
 CHARM_LIB_DIR = os.environ.get('CHARM_DIR', '') + "/lib/"
 
 
@@ -70,6 +74,7 @@ class CPlanePackageManager:
                           % (version, package_name))
             return
 
+        mkdir(CHARM_LIB_DIR)
         filename = urlparse.urlsplit(package_dwnld_link).path
         dwnld_package_name = os.path.join(CHARM_LIB_DIR,
                                           os.path.basename(filename))

--- a/neutron-openvswitch-cplane/hooks/cplane_package_manager.py
+++ b/neutron-openvswitch-cplane/hooks/cplane_package_manager.py
@@ -6,6 +6,10 @@ import json
 import hashlib
 import urlparse
 
+from charmhelpers.core.host import (
+    mkdir,
+)
+
 CHARM_LIB_DIR = os.environ.get('CHARM_DIR', '') + "/lib/"
 
 
@@ -70,6 +74,7 @@ class CPlanePackageManager:
                           % (version, package_name))
             return
 
+        mkdir(CHARM_LIB_DIR)
         filename = urlparse.urlsplit(package_dwnld_link).path
         dwnld_package_name = os.path.join(CHARM_LIB_DIR,
                                           os.path.basename(filename))


### PR DESCRIPTION
The package manager is attempting to download packages to $CHARM_DIR/lib but
fails when the lib subdirectory does not exist. Add it if it does not already
exist.