### PR TITLE
Validate package manager JSON and Net Interfaces

### DIFF
--- a/neutron-api-cplane/hooks/cplane_package_manager.py
+++ b/neutron-api-cplane/hooks/cplane_package_manager.py
@@ -6,6 +6,10 @@ import json
 import hashlib
 import urlparse
 
+from charmhelpers.core.host import (
+    mkdir,
+)
+
 CHARM_LIB_DIR = os.environ.get('CHARM_DIR', '') + "/lib/"
 
 
@@ -70,6 +74,7 @@ class CPlanePackageManager:
                           % (version, package_name))
             return
 
+        mkdir(CHARM_LIB_DIR)
         filename = urlparse.urlsplit(package_dwnld_link).path
         dwnld_package_name = os.path.join(CHARM_LIB_DIR,
                                           os.path.basename(filename))

--- a/neutron-api-cplane/hooks/cplane_package_manager.py
+++ b/neutron-api-cplane/hooks/cplane_package_manager.py
@@ -10,7 +10,15 @@ from charmhelpers.core.host import (
     mkdir,
 )
 
+from charmhelpers.core.hookenv import (
+    status_set,
+)
+
 CHARM_LIB_DIR = os.environ.get('CHARM_DIR', '') + "/lib/"
+
+
+class JsonException(Exception):
+    pass
 
 
 class CPlanePackageManager:
@@ -30,11 +38,19 @@ class CPlanePackageManager:
                             datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO)
         logging.info("Writing to log file : %s" % log_file)
 
+    def _validate_json(self, data):
+        try:
+            return json.loads(data)
+        except ValueError as e:
+            msg = "JSON Error: {}".format(e.message)
+            status_set('blocked', msg)
+            raise JsonException(msg)
+
     def _get_pkg_json(self):
         url = self.package_url
         response = urllib.urlopen(url)
         logging.info("Package url:%s" % url)
-        data = json.loads(response.read())
+        data = self._validate_json(response.read())
         self.package_data = data.get("1.3.5",
                                      {}).get("ubuntu",
                                              {}).get("14.04",

--- a/neutron-openvswitch-cplane/hooks/cplane_package_manager.py
+++ b/neutron-openvswitch-cplane/hooks/cplane_package_manager.py
@@ -6,6 +6,10 @@ import json
 import hashlib
 import urlparse
 
+from charmhelpers.core.host import (
+    mkdir,
+)
+
 CHARM_LIB_DIR = os.environ.get('CHARM_DIR', '') + "/lib/"
 
 
@@ -70,6 +74,7 @@ class CPlanePackageManager:
                           % (version, package_name))
             return
 
+        mkdir(CHARM_LIB_DIR)
         filename = urlparse.urlsplit(package_dwnld_link).path
         dwnld_package_name = os.path.join(CHARM_LIB_DIR,
                                           os.path.basename(filename))

--- a/neutron-openvswitch-cplane/hooks/cplane_package_manager.py
+++ b/neutron-openvswitch-cplane/hooks/cplane_package_manager.py
@@ -10,7 +10,15 @@ from charmhelpers.core.host import (
     mkdir,
 )
 
+from charmhelpers.core.hookenv import (
+    status_set,
+)
+
 CHARM_LIB_DIR = os.environ.get('CHARM_DIR', '') + "/lib/"
+
+
+class JsonException(Exception):
+    pass
 
 
 class CPlanePackageManager:
@@ -30,11 +38,19 @@ class CPlanePackageManager:
                             datefmt='%m/%d/%Y %I:%M:%S %p', level=logging.INFO)
         logging.info("Writing to log file : %s" % log_file)
 
+    def _validate_json(self, data):
+        try:
+            return json.loads(data)
+        except ValueError as e:
+            msg = "JSON Error: {}".format(e.message)
+            status_set('blocked', msg)
+            raise JsonException(msg)
+
     def _get_pkg_json(self):
         url = self.package_url
         response = urllib.urlopen(url)
         logging.info("Package url:%s" % url)
-        data = json.loads(response.read())
+        data = self._validate_json(response.read())
         self.package_data = data.get("1.3.5",
                                      {}).get("ubuntu",
                                              {}).get("14.04",

--- a/neutron-openvswitch-cplane/unit_tests/test_cplane_network.py
+++ b/neutron-openvswitch-cplane/unit_tests/test_cplane_network.py
@@ -7,6 +7,22 @@ import netifaces as ni
 TO_PATCH = [
 ]
 
+NI_OUTPUT = {'ethX': {17: [{'broadcast': 'ff:ff:ff:ff:ff:ff',
+                            'addr': 'e5:59:e5:41:19:88'}],
+                      2: [{'broadcast': '10.0.63.255',
+                           'netmask': '255.255.192.0',
+                           'addr': '10.0.1.4'}],
+                      10: [{'netmask': 'ffff:ffff:ffff:ffff::',
+                            'addr': 'fe80::e559:e5ff:fe41:1988%br-eth0'}]}}
+NI_OUTPUT_NO_AF = {'ethX': {17: [{'broadcast': 'ff:ff:ff:ff:ff:ff',
+                                  'addr': 'e5:59:e5:41:19:88'}],
+                            10: [{'netmask': 'ffff:ffff:ffff:ffff::',
+                                  'addr': 'fe80::e559:e5ff:fe41:1988%br-eth0'}]
+                            }}
+NI_EXPECTED = {2: [{'broadcast': '10.0.63.255',
+                    'netmask': '255.255.192.0',
+                    'addr': '10.0.1.4'}]}
+
 
 class CplaneNetworkTest(CharmTestCase):
 
@@ -38,6 +54,27 @@ class CplaneNetworkTest(CharmTestCase):
 
         # check for invalid interface
         self.assertEqual(cplane_network.check_interface('cplane'), False)
+
+    @patch.object(cplane_network, 'ni')
+    def test_get_int_config(self, m_ni):
+        m_ni.interfaces.return_value = NI_OUTPUT
+        m_ni.ifaddresses.return_value = NI_OUTPUT['ethX']
+        self.assertEqual(cplane_network.get_int_config('ethX'),
+                         NI_EXPECTED[ni.AF_INET])
+
+    @patch.object(cplane_network, 'ni')
+    def test_get_int_config_no_int(self, m_ni):
+        m_ni.interfaces.return_value = NI_OUTPUT
+        with self.assertRaises(cplane_network.InterfaceConfigurationException):
+            cplane_network.get_int_config('ethY')
+
+    @patch.object(cplane_network, 'ni')
+    def test_get_int_config_no_af(self, m_ni):
+        m_ni.interfaces.return_value = NI_OUTPUT_NO_AF
+        m_ni.ifaddresses.return_value = NI_OUTPUT_NO_AF['ethX']
+        with self.assertRaises(cplane_network.InterfaceConfigurationException):
+            cplane_network.get_int_config('ethX')
+
 
 suite = unittest.TestLoader().loadTestsFromTestCase(CplaneNetworkTest)
 unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
This is just an example. Please feel free to reject this pull request. No feelings hurt :)

When pulling the package manager JSON validate the JSON and provide feedback to the end user if it is invalid. 
When getting net interfaces data validate what is expected and provide feedback when expected data is missing.

We would then get status outputs like the following in error scenarios:
juju status-history neutron-openvswitch-cplane/0

TIME                            TYPE            STATUS          MESSAGE
25 Aug 2016 09:53:58-07:00      juju-unit       executing       running install hook
25 Aug 2016 10:09:34-07:00      workload        blocked         JSON Error: Expecting property name: line 56 column 13 (char 2519)
25 Aug 2016 10:10:50-07:00      workload        maintenance     installing charm software

TIME                            TYPE            STATUS          MESSAGE
25 Aug 2016 10:10:50-07:00      juju-unit       executing       running install hook
25 Aug 2016 10:15:02-07:00      workload        blocked         Interface eth1 does not have an address in the address family 2
25 Aug 2016 10:15:02-07:00      juju-unit       error           hook failed: "install"
