### PR TITLE
Metadata context

### DIFF
--- a/neutron-openvswitch-cplane/config.yaml
+++ b/neutron-openvswitch-cplane/config.yaml
@@ -14,7 +14,7 @@ options:
   rabbit-user:
     type: string
     default: "neutron"
-    description: "Nova rabbit user name"
+    description: "Neutron rabbit user name"
   rabbit-vhost:
     type: string
     default: "openstack"
@@ -58,6 +58,6 @@ options:
       URL for cplane packages
       if from local repo then "http://xx.xx.xx.xx/cplane_metadata.json"
   metadata-shared-secret:
-    default: "secret"
     type: string
+    default:
     description: "Metadata shared secret"

--- a/neutron-openvswitch-cplane/hooks/neutron-plugin-api-relation-changed
+++ b/neutron-openvswitch-cplane/hooks/neutron-plugin-api-relation-changed
@@ -1,0 +1,1 @@
+cplane_hooks.py

--- a/neutron-openvswitch-cplane/metadata.yaml
+++ b/neutron-openvswitch-cplane/metadata.yaml
@@ -21,6 +21,8 @@ requires:
   container:
     interface: juju-info
     scope: container
+  neutron-plugin-api:
+    interface: neutron-plugin-api
   cplane-controller:
     interface: cplane-controller
   amqp:

--- a/neutron-openvswitch-cplane/templates/metadata_agent.ini
+++ b/neutron-openvswitch-cplane/templates/metadata_agent.ini
@@ -2,10 +2,18 @@
 # [ WARNING ]
 # Configuration file maintained by Juju. Local changes may be overwritten.
 ###############################################################################
-[DEFAULT]
-{% include "section-keystone-authtoken-metadata" %}
-nova_metadata_ip = {{ metadata_ip }}
-metadata_proxy_shared_secret = {{ shared_secret }}
+# Metadata service seems to cache neutron api url from keystone so trigger
+# restart if it changes: {{ quantum_url }}
+# {{ restart_trigger_metadata }}
 
-{% include "section-rabbitmq-oslo" %}
-[AGENT]
+[DEFAULT]
+auth_url = {{ service_protocol }}://{{ service_host }}:{{ service_port }}/v2.0
+auth_region = {{ region }}
+admin_tenant_name = {{ admin_tenant_name }}
+admin_user = {{ admin_user }}
+admin_password = {{ admin_password }}
+root_helper = sudo neutron-rootwrap /etc/neutron/rootwrap.conf
+state_path = /var/lib/neutron
+nova_metadata_port = 8775
+metadata_proxy_shared_secret = {{ shared_secret }}
+cache_url = memory://?default_ttl=5

--- a/neutron-openvswitch-cplane/templates/section-keystone-authtoken-metadata
+++ b/neutron-openvswitch-cplane/templates/section-keystone-authtoken-metadata
@@ -1,8 +1,0 @@
-{% if auth_host -%}
-auth_url = {{ service_protocol }}://{{ service_host }}:{{ service_port }}/v2.0/
-auth_region = {{ region }}
-admin_tenant_name = {{ admin_tenant_name }}
-username = {{ admin_user }}
-password = {{ admin_password }}
-{% endif -%}
-

--- a/neutron-openvswitch-cplane/unit_tests/test_cplane_utils.py
+++ b/neutron-openvswitch-cplane/unit_tests/test_cplane_utils.py
@@ -106,12 +106,5 @@ class CplaneUtilsTest(CharmTestCase):
         self.assertEqual(m_check_call.call_args, call(['update-rc.d',
                                                        'cp-agentd', 'enable']))
 
-    @patch("subprocess.check_call")
-    def test_restart_metadata_agent(self, m_check_call):
-        cplane_utils.restart_metadata_agent()
-        self.assertEqual(m_check_call.call_args,
-                         call(['service', 'neutron-metadata-agent',
-                               'restart']))
-
 suite = unittest.TestLoader().loadTestsFromTestCase(CplaneUtilsTest)
 unittest.TextTestRunner(verbosity=2).run(suite)

--- a/yaml/ceph_controller_cumpute_nodes.yaml
+++ b/yaml/ceph_controller_cumpute_nodes.yaml
@@ -75,12 +75,12 @@ relations:
   - rabbitmq-server:amqp
 - - neutron-openvswitch-cplane:neutron-plugin
   - nova-compute:neutron-plugin
+- - neutron-openvswitch-cplane:neutron-plugin-api
+  - nova-compute:neutron-plugin-api
 - - neutron-openvswitch-cplane:amqp
   - rabbitmq-server:amqp
 - - neutron-openvswitch-cplane:amqp
   - rabbitmq-server:amqp
-- - neutron-openvswitch-cplane:identity-service
-  - keystone:identity-service
 - - neutron-api-cplane:shared-db
   - mysql:shared-db
 

--- a/yaml/cplane_openstack.yaml
+++ b/yaml/cplane_openstack.yaml
@@ -76,10 +76,10 @@ relations:
   - rabbitmq-server:amqp
 - - neutron-openvswitch-cplane:neutron-plugin
   - nova-compute:neutron-plugin
+- - neutron-openvswitch-cplane:neutron-plugin-api
+  - nova-compute:neutron-plugin-api
 - - neutron-openvswitch-cplane:amqp
   - rabbitmq-server:amqp
-- - neutron-openvswitch-cplane:identity-service
-  - keystone:identity-service
 - - cplane-compute:amqp
   - rabbitmq-server:amqp
 - - cplane-compute:image-service


### PR DESCRIPTION
Enable nova-api-metadata agent on the compute node

Use contexts and register_configs for neutron-metadata-agent
Rely on nova-compute to run nova-api-metadata
