### PR TITLE
Guarantee flush of IP for underlying bridge int

### DIFF
--- a/neutron-openvswitch-cplane/hooks/cplane_network.py
+++ b/neutron-openvswitch-cplane/hooks/cplane_network.py
@@ -71,8 +71,6 @@ def add_bridge(name, interface, gw=None):
     extra_params = dict([(k, "".join(list(v))) for k, v in extra_params
                          .iteritems()])
 
-    cmd = ['ifdown', interface, ]
-    subprocess.check_call(cmd)
 
     network_configuration._write_net_config_bridged_iface_br(interface,
                                                              **extra_params)
@@ -85,6 +83,10 @@ def add_bridge(name, interface, gw=None):
 
 
 def restart_network_service(name, interface):
+    cmd = ['ifdown', interface, ]
+    subprocess.check_call(cmd)
+    cmd = ['ip', 'addr', 'flush', 'dev', interface]
+    subprocess.check_call(cmd)
     cmd = ['ifup', name, ]
     subprocess.check_call(cmd)
 


### PR DESCRIPTION
When ifdown is called on an interface without an 'addr' setting
there is no guarantee the IP will be flushed from the interface.
If the IP remains on the underlying interface the br-ext bridge
relies on the CPlane SDN fails to respond.

Guarantee the IP is flushed from the underlying bridge interface by
calling a gratuitous `ip flush`